### PR TITLE
fix(auth): revoke JWT access for deleted accounts

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -6,12 +6,14 @@ import { ChatsModule } from './chats/chats.module';
 import { QuestionsModule } from './questions/questions.module';
 import { AuthModule } from './auth/auth.module';
 import dbConfig from './config/db.config';
+import { CacheModule } from '@nestjs/cache-manager';
 
 @Module({
   imports: [
     //Loading the .env variables
     ConfigModule.forRoot({ load: [dbConfig], isGlobal: true }),
     TypeOrmModule.forRootAsync(dbConfig.asProvider()),
+    CacheModule.register({ isGlobal: true }),
     UsersModule,
     ChatsModule,
     QuestionsModule,

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -4,14 +4,20 @@ import {
   Get,
   Post,
   Request,
+  Response,
   UseGuards,
 } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { CreateUserDto } from 'src/users/dto/create-user.dto';
-import { Request as ExpressRequest } from 'express';
+import {
+  Request as ExpressRequest,
+  Response as ExpressResponse,
+} from 'express';
 import { LocalGuard } from './guards/local.guard';
 import { RequestUser } from './constants/requestUser';
 import { GoogleGuard } from './guards/google.guard';
+import { RefreshGuard } from './guards/refresh-jwt.guard';
+import { AuthenticatedRequest } from './constants/authenticatedRequest';
 
 @Controller('auth')
 export class AuthController {
@@ -24,16 +30,24 @@ export class AuthController {
 
   @Post('login')
   @UseGuards(LocalGuard)
-  login(@Request() req: ExpressRequest) {
-    return this.authService.login(req.user as RequestUser);
+  async login(
+    @Request() req: ExpressRequest,
+    @Response() res: ExpressResponse,
+  ) {
+    const { refreshToken, accessToken } = await this.authService.login(
+      req.user as RequestUser,
+    );
+
+    //TODO: Add security to cookie storage
+    res.cookie('refreshToken', refreshToken);
+
+    //Sending responses the express way because we need to set a cookie
+    res.status(200).json({ refreshToken, accessToken });
   }
 
   @Get('google')
   @UseGuards(GoogleGuard)
-  loginWithGoogle(@Request() req: ExpressRequest) {
-    console.log('pŕimeiro passo do oauth2');
-    return 'sadsad';
-  }
+  loginWithGoogle() {}
 
   @Get('google/post')
   //OAuth2 needs two get routes, the first one is merely to hit the authentication, it will not even be executed (handler), we need to send it to a second route which is where we actually get our req.user populated and finally send a response
@@ -41,5 +55,13 @@ export class AuthController {
   @UseGuards(GoogleGuard)
   loginWithGooglePost(@Request() req: ExpressRequest) {
     return this.authService.login(req.user as RequestUser);
+  }
+
+  //Whenever acesstoken is expired, the client must try and hit this route, if their refresh token is not expired and is valid, they will be issued a new access token with the payload contained in the refreshToken, which is the same as the one in acessToken
+  @Post('refresh')
+  @UseGuards(RefreshGuard)
+  refreshToken(@Request() req: AuthenticatedRequest) {
+    const payloadFromRefresh = { sub: req.user.sub, role: req.user.role };
+    return this.authService.refreshToken(payloadFromRefresh);
   }
 }

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -9,6 +9,8 @@ import { JWTStrategy } from './strategies/jwt.strategy';
 import { GoogleStrategy } from './strategies/google.strategy';
 import jwtModuleConfig from './config/jwtModule.config';
 import { ConfigModule } from '@nestjs/config';
+import refreshJwtConfig from './config/refreshJwt.config';
+import { RefreshJWTStrategy } from './strategies/refresh-jwt.strategy';
 
 @Module({
   imports: [
@@ -16,8 +18,15 @@ import { ConfigModule } from '@nestjs/config';
     PassportModule,
     JwtModule.registerAsync(jwtModuleConfig.asProvider()),
     ConfigModule.forFeature(jwtModuleConfig),
+    ConfigModule.forFeature(refreshJwtConfig),
   ],
   controllers: [AuthController],
-  providers: [AuthService, LocalStrategy, JWTStrategy, GoogleStrategy],
+  providers: [
+    AuthService,
+    LocalStrategy,
+    JWTStrategy,
+    RefreshJWTStrategy,
+    GoogleStrategy,
+  ],
 })
 export class AuthModule {}

--- a/src/auth/config/jwtModule.config.ts
+++ b/src/auth/config/jwtModule.config.ts
@@ -4,6 +4,7 @@ export default registerAs('jwtModuleConfig', () => {
   console.log(process.env.JWT_SECRET);
   return {
     secret: process.env.JWT_SECRET,
-    signOptions: { expiresIn: '10h' },
+    //Expiration time for access token is decreased
+    signOptions: { expiresIn: '15s' },
   };
 });

--- a/src/auth/config/jwtModule.config.ts
+++ b/src/auth/config/jwtModule.config.ts
@@ -1,10 +1,14 @@
 import { registerAs } from '@nestjs/config';
+import { JwtModuleOptions } from '@nestjs/jwt';
 
-export default registerAs('jwtModuleConfig', () => {
-  console.log(process.env.JWT_SECRET);
-  return {
-    secret: process.env.JWT_SECRET,
-    //Expiration time for access token is decreased
-    signOptions: { expiresIn: '15s' },
-  };
-});
+export default registerAs(
+  'jwtModuleConfig',
+  (): Pick<JwtModuleOptions, 'secret' | 'signOptions'> => {
+    console.log(process.env.JWT_SECRET);
+    return {
+      secret: process.env.JWT_SECRET,
+      //Expiration time for access token is decreased
+      signOptions: { expiresIn: '1h' },
+    };
+  },
+);

--- a/src/auth/config/refreshJwt.config.ts
+++ b/src/auth/config/refreshJwt.config.ts
@@ -1,0 +1,10 @@
+import { registerAs } from '@nestjs/config';
+import { JwtSignOptions } from '@nestjs/jwt';
+
+export default registerAs(
+  'refreshTokenConfig',
+  (): JwtSignOptions => ({
+    expiresIn: '7d',
+    secret: process.env.REFRESH_JWT_SECRET,
+  }),
+);

--- a/src/auth/constants/authenticatedRequest.ts
+++ b/src/auth/constants/authenticatedRequest.ts
@@ -3,4 +3,5 @@ import { JWTPayload } from './jwtPayload';
 
 export class AuthenticatedRequest extends Request {
   user: JWTPayload;
+  cookies: { refreshToken: string };
 }

--- a/src/auth/guards/refresh-jwt.guard.ts
+++ b/src/auth/guards/refresh-jwt.guard.ts
@@ -1,0 +1,3 @@
+import { AuthGuard } from '@nestjs/passport';
+
+export class RefreshGuard extends AuthGuard('refresh-jwt') {}

--- a/src/auth/strategies/jwt.strategy.ts
+++ b/src/auth/strategies/jwt.strategy.ts
@@ -1,8 +1,11 @@
-import { Inject, Injectable } from '@nestjs/common';
+import { Inject, Injectable, UnauthorizedException } from '@nestjs/common';
 import { ConfigType } from '@nestjs/config';
 import { PassportStrategy } from '@nestjs/passport';
 import { ExtractJwt, Strategy } from 'passport-jwt';
 import jwtModuleConfig from '../config/jwtModule.config';
+import { Request } from 'express';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import { Cache } from 'cache-manager';
 
 //Unlike local strat, used to initiate the login validation, which then influences the controller directly thru req.use to generate a token, this one is more of a normal guard, so it does not initiate the auth or anything, it simply acts as a guard in the sense of deciding whether the handler'll be hit or not
 
@@ -11,17 +14,26 @@ export class JWTStrategy extends PassportStrategy(Strategy) {
   constructor(
     @Inject(jwtModuleConfig.KEY)
     private readonly configService: ConfigType<typeof jwtModuleConfig>,
+    @Inject(CACHE_MANAGER) private cacheManager: Cache,
   ) {
     super({
       jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
       secretOrKey: configService.secret,
       ignoreExpiration: false,
+      passReqToCallback: true,
     });
   }
 
   //This validate receives only the decoded token, this fn is only triggered in case our code was successfully decoded, otherwise, it'll throw an 401 Unauthorized and not hit the handler being protected by this guard
-  async validate(token) {
+  async validate(req: Request, token) {
     //TODO: Fetch user's most up-to-date role inside here and include it in the token
+    //Fetching to see if accessToken is in cache (blacklisted)
+    const accessToken = req.headers.authorization.split(' ')[1];
+    const accessTokenIsInCache = await this.cacheManager.get(accessToken);
+
+    //Throwing unauthorized if so
+    if (accessTokenIsInCache) throw new UnauthorizedException();
+
     console.log(token);
     return token;
   }

--- a/src/auth/strategies/refresh-jwt.strategy.ts
+++ b/src/auth/strategies/refresh-jwt.strategy.ts
@@ -1,0 +1,32 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { ConfigType } from '@nestjs/config';
+import { PassportStrategy } from '@nestjs/passport';
+import { ExtractJwt, Strategy } from 'passport-jwt';
+import refreshJwtConfig from '../config/refreshJwt.config';
+import { extractJwtFromCookie } from '../utils/helpers';
+
+//Unlike local strat, used to initiate the login validation, which then influences the controller directly thru req.use to generate a token, this one is more of a normal guard, so it does not initiate the auth or anything, it simply acts as a guard in the sense of deciding whether the handler'll be hit or not
+
+@Injectable()
+export class RefreshJWTStrategy extends PassportStrategy(
+  Strategy,
+  'refresh-jwt',
+) {
+  constructor(
+    @Inject(refreshJwtConfig.KEY)
+    private readonly configService: ConfigType<typeof refreshJwtConfig>,
+  ) {
+    super({
+      jwtFromRequest: ExtractJwt.fromExtractors([extractJwtFromCookie]),
+      secretOrKey: configService.secret,
+      ignoreExpiration: false,
+    });
+  }
+
+  //This validate receives only the decoded token, this fn is only triggered in case our code was successfully decoded, otherwise, it'll throw an 401 Unauthorized and not hit the handler being protected by this guard
+  async validate(token) {
+    //TODO: Fetch user's most up-to-date role inside here and include it in the token
+    console.log(token);
+    return token;
+  }
+}

--- a/src/auth/strategies/refresh-jwt.strategy.ts
+++ b/src/auth/strategies/refresh-jwt.strategy.ts
@@ -1,9 +1,13 @@
-import { Inject, Injectable } from '@nestjs/common';
+import { Inject, Injectable, UnauthorizedException } from '@nestjs/common';
 import { ConfigType } from '@nestjs/config';
 import { PassportStrategy } from '@nestjs/passport';
 import { ExtractJwt, Strategy } from 'passport-jwt';
 import refreshJwtConfig from '../config/refreshJwt.config';
 import { extractJwtFromCookie } from '../utils/helpers';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import { Cache } from 'cache-manager';
+import { Request } from 'express';
+import { JWTPayload } from '../constants/jwtPayload';
 
 //Unlike local strat, used to initiate the login validation, which then influences the controller directly thru req.use to generate a token, this one is more of a normal guard, so it does not initiate the auth or anything, it simply acts as a guard in the sense of deciding whether the handler'll be hit or not
 
@@ -15,18 +19,27 @@ export class RefreshJWTStrategy extends PassportStrategy(
   constructor(
     @Inject(refreshJwtConfig.KEY)
     private readonly configService: ConfigType<typeof refreshJwtConfig>,
+    @Inject(CACHE_MANAGER) private cacheManager: Cache,
   ) {
     super({
       jwtFromRequest: ExtractJwt.fromExtractors([extractJwtFromCookie]),
       secretOrKey: configService.secret,
       ignoreExpiration: false,
+      passReqToCallback: true,
     });
   }
 
   //This validate receives only the decoded token, this fn is only triggered in case our code was successfully decoded, otherwise, it'll throw an 401 Unauthorized and not hit the handler being protected by this guard
-  async validate(token) {
+  async validate(req: Request, token: JWTPayload) {
     //TODO: Fetch user's most up-to-date role inside here and include it in the token
-    console.log(token);
+    const refreshTokenIsInCache = await this.cacheManager.get(
+      req.cookies.refreshToken,
+    );
+
+    //For debugging purposes
+    console.log(refreshTokenIsInCache);
+
+    if (!refreshTokenIsInCache) throw new UnauthorizedException();
     return token;
   }
 }

--- a/src/auth/utils/helpers.ts
+++ b/src/auth/utils/helpers.ts
@@ -1,0 +1,7 @@
+import { Request } from 'express';
+
+export function extractJwtFromCookie(req: Request): string {
+  console.log(req);
+  console.log(req.cookies);
+  return req.cookies.refreshToken;
+}

--- a/src/auth/utils/helpers.ts
+++ b/src/auth/utils/helpers.ts
@@ -1,7 +1,7 @@
 import { Request } from 'express';
 
 export function extractJwtFromCookie(req: Request): string {
-  console.log(req);
-  console.log(req.cookies);
+  // console.log(req);
+  // console.log(req.cookies);
   return req.cookies.refreshToken;
 }

--- a/src/constants/env.ts
+++ b/src/constants/env.ts
@@ -7,4 +7,6 @@ export interface EnvironmentVariables {
   JWT_SECRET: string;
   GOOGLE_OAUTH2_CLIENTID: string;
   GOOGLE_OAUTH2_CLIENTSECRET: string;
+  ACCESS_TOKEN_BLACKLIST_TTL: number;
+  REFRESH_TOKEN_WHITELIST_TTL: number;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,9 +1,11 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { ValidationPipe } from '@nestjs/common';
+import * as cookieParser from 'cookie-parser';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+  app.use(cookieParser());
   //Applying a validation pipe (the bultin one that uses class-validator) to every endpoint
   app.useGlobalPipes(new ValidationPipe());
   await app.listen(process.env.PORT ?? 3000);


### PR DESCRIPTION
This PR addresses an issue where users could access routes guarded by JwtGuard even after their account was deleted, as long as they possessed an unexpired token. Tokens currently have a 10-hour lifespan, and no mechanism existed to revoke tokens dynamically. This also applies for logged-out users, who could also make use of this bug. The changes made make sure a user can neither generate new access tokens with the latest refresh token they had upon account deletion/logging out, nor using their last, possibly unexpired, access token to access routes guarded by JwtGuard.

# Changes
- In-memory whitelist of valid refresh tokens, that is, refresh tokens that may emit new access tokens. TTL is 7 days.
- In-memory blacklist of invalid access tokens, that is, the last token a user has had access to. TTL is 1 hour.

# Related Issue
Fixes #1: Users can access routes guarded by JwtGuard after account deletion.